### PR TITLE
fix parsl runner imports

### DIFF
--- a/paropt/runner/parsl/__init__.py
+++ b/paropt/runner/parsl/__init__.py
@@ -1,6 +1,6 @@
 from .parsl_runner import ParslRunner
-from .config import parslConfigFromCompute
-from .lib import timeCommand
+from .config import parslConfigFromCompute as local_config
+from .lib import timeCommand as timeCmd
 
 __all__ = [
   'ParslRunner',


### PR DESCRIPTION
issue importing dependencies using __all__ aliasing, requires explicit import before passing to __all__ in __init__.py. unsure if this is a global issue, though this update does not seem to break anything.